### PR TITLE
Fix tauri link

### DIFF
--- a/open-in-web-browser.html
+++ b/open-in-web-browser.html
@@ -149,7 +149,7 @@
               <a href="https://www.electronjs.org/">Electron</a> for desktop
               apps <a href="https://reactnative.dev/">React Native</a> and
               <a href="https://capacitorjs.com/">Capacitor</a> for mobile apps
-              and even newer solutions like <a href="https://beta.tauri.app/guides/">Tauri V2</a> that
+              and even newer solutions like <a href="https://beta.tauri.app/start/">Tauri V2</a> that
               supports both mobile and desktop operating systems. Note that
               native applications built from web technologies either run web
               technologies at runtime (e.g., Electron, Tauri) or translate to


### PR DESCRIPTION
### The current link opens a missing page

![image](https://github.com/FrontendMasters/front-end-handbook-2024/assets/73728149/f02a8115-3672-4508-8c74-75892d06df95)

### Here's where the new link would lead

![image](https://github.com/FrontendMasters/front-end-handbook-2024/assets/73728149/46b4c471-a88c-4c96-93be-cfcb5549070e)
